### PR TITLE
support for bad argument The request has different granularities for …

### DIFF
--- a/OaiPmhNet/DataProvider.cs
+++ b/OaiPmhNet/DataProvider.cs
@@ -361,6 +361,9 @@ namespace OaiPmhNet
             if (fromDate > untilDate)
                 return CreateErrorDocument(date, verb, arguments, OaiErrors.BadFromUntilCombinationArgument);
 
+            if (!string.IsNullOrWhiteSpace(arguments.Until) && !string.IsNullOrWhiteSpace(arguments.From) && arguments.Until.Length!=arguments.From.Length)
+                return CreateErrorDocument(date,verb,arguments,OaiErrors.BadUntilFromArgument);
+                
             // Decode ResumptionToken
             if (resumptionToken == null && !string.IsNullOrWhiteSpace(arguments.ResumptionToken))
             {

--- a/OaiPmhNet/OaiErrors.cs
+++ b/OaiPmhNet/OaiErrors.cs
@@ -34,6 +34,8 @@ namespace OaiPmhNet
             "The request includes a 'from' argument that has an illegal syntax / granularity.");
         public static XElement BadUntilArgument => Error("badArgument",
             "The request includes a 'until' argument that has an illegal syntax / granularity.");
+        public static XElement BadUntilFromArgument => Error("badArgument",
+            "The request has different granularities for the from and until parameters.");
 
         // Verb
         public static XElement BadVerb => Error("badVerb",


### PR DESCRIPTION
support for bad argument The request has different granularities for the from and until parameters.

This is a version 2.0 validation requirement for the oai validation service:
http://www.openarchives.org/Register/ValidateSite

